### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   test:
     name: Lint
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go Test
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/elfranne/mmdb_lookup/security/code-scanning/3](https://github.com/elfranne/mmdb_lookup/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow or the specific job. The minimal starting point is `contents: read`, but GoReleaser typically needs to create releases and upload assets, which requires `contents: write`. Therefore, the best fix is to add a `permissions` block at the job level (under `goreleaser:`) with `contents: write`. This ensures the job has only the permissions it needs, and no more. The change should be made in `.github/workflows/release.yml`, directly under the `goreleaser:` job definition (after `runs-on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
